### PR TITLE
Use IPv4 DNS to resolve IPv6 AAAA addresses (workaround)

### DIFF
--- a/update-airvpn-ips.sh
+++ b/update-airvpn-ips.sh
@@ -26,6 +26,10 @@ set -euo pipefail
 : ${NS_V4:="8.8.4.4"}
 : ${NS_V6:="2001:4860:4860::8844"}
 
+# TODO: IPv6 shows "address unreachable" due to some OrbStack/ip6tables issues.
+#  As a workaround, use the IPv4 DNS to resolve IPv6 AAAA records — good enough.
+NS_V6="$NS_V4"
+
 # Where the cache of the VPN provider's IP addresses should be stored.
 # The main file is "all.txt". Other files can exist, one per requested scope.
 : ${ALLOWED_IPS_DIR:="$(dirname $0)/cache/servers"}


### PR DESCRIPTION
Currently, IPv6 does not work entirely in OrbStack with ip6tables on — even with permissive rules. It works when the firewall is off, but this breaks the point of the project. This blocks the resolution of AirVPN hostnames into AAAA addresses when the IPv6 DNS is used. Which, in turn, blocks the proper IPv6 firewall configuration.

I could not find the cause of this issue. Instead, I redirect all IPv6 AAAA DNS queries to an IPv4 DNS server — i.e. over the IPv4 stack, which works fine. This unblocks the firewall configuration and, in theory, the IPv6 stack for the app — assuming that IPv6 is somehow functional at all.

This should be a temporary solution until a proper fix for IPv6 stack is found (no prognoses though).

For this particular example, this is irrelevant — Transmission does not support IPv6, it seems, only IPv4, so it will not feel a difference. Other useful apps might require or support IPv6.